### PR TITLE
DR-943 - Add a Python API client example using "requests" module

### DIFF
--- a/python-requests-api-cli-example/Dockerfile
+++ b/python-requests-api-cli-example/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:2.7.12
+
+# Replace with your values
+ENV DOPPLERRELAY_ACCOUNT_ID 12345 
+ENV DOPPLERRELAY_ACCOUNT_NAME my-account-name
+ENV DOPPLERRELAY_APIKEY my_api_key
+
+# Copy current code
+WORKDIR /usr/src/python-requests-api-cli-example
+COPY . .
+
+# Install dependencies
+RUN pip install requests
+
+# Example script
+CMD [ "python", "./python-requests-api-cli-example.py" ]

--- a/python-requests-api-cli-example/python-requests-api-cli-example.py
+++ b/python-requests-api-cli-example/python-requests-api-cli-example.py
@@ -1,0 +1,33 @@
+import requests # it is an external module, use `pip install requests`
+import json
+import os
+
+accountId = os.environ['DOPPLERRELAY_ACCOUNT_ID']
+apikey = os.environ['DOPPLERRELAY_APIKEY']
+
+url = 'http://api.dopplerrelay.com/accounts/' + accountId + '/messages'
+
+data = {
+    'from_name': 'Your Name',
+    'from_email': 'test@example.com',
+    'recipients': [
+        {
+            'type': 'to',
+            'email': 'test@example.com',
+            'name': 'Test Recipient'
+        }
+    ],
+    'subject': 'Testing Doppler Relay',
+    'html': '<strong>Doppler Relay</strong> is great!'  
+}
+
+headers = {
+    'Authorization': 'token ' + apikey,
+    'Content-type': 'application/json'
+}
+
+req = requests.post(url, data=json.dumps(data), headers=headers)
+
+print(req.text)
+
+req.raise_for_status()


### PR DESCRIPTION
Hi @nreal, @mvillaseco, @pbarrios, @martinkeimel and @matiasbeckerle (because you have reviewed PHP version and you have a nice common sense),

It is a little minimum example to be included in our site, could you review?

I am not sure about Python coding style and conventions, please let me know if you think if something could be improved.

I am using [Requests external module](http://docs.python-requests.org/en/latest/index.html) that seems to be pretty common.

Thanks!